### PR TITLE
chore: support for tweepy>4.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tidytwitter
-version = 0.1.9
+version = 0.2.0
 description = Delete your old tweets and favorites using the Twitter API
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -29,7 +29,7 @@ package_dir = =src
 packages = find:
 python_requires = >=3.7
 install_requires =
-    tweepy<4.0.0
+    tweepy
     click
 
 [options.packages.find]


### PR DESCRIPTION
tweepy 4.0.0 introduced a number of breaking changes. This commit adds support for those changes, while retaining backwards compatibility with earlier versions of tweepy.

See https://github.com/tweepy/tweepy/releases/tag/v4.0.0 for the full set of changes. The ones that affect tidytwitter are

 - `wait_on_rate_limit_notify` is no longer an option
 - s/favorites/get_favorites
 - s/me/verify_credentials
 - the `created_at` attribute of a tweet is no longer timezone naive

The last of these requires a couple of changes in order to retain backwards compatibility with tweepy<4.0.0. First we ensure the "now" time is tz aware (see https://blog.ganssle.io/articles/2019/11/utcnow.html) so >4.0.0 works,
and then we ensure the created_at time is also tz aware so that <4.0.0 still works.